### PR TITLE
add osg-cpu-hours.json output file (SOFTWARE-4437)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ The following metrics results are for the past 7 days.
 
 [`campuses-with-active-researchers.csv`](campuses-with-active-researchers.csv)
 
+### OSG CPU Hours
+
+[`osg-cpu-hours.json`](osg-cpu-hours.json)
+


### PR DESCRIPTION
depends on https://github.com/path-cc/metric-tools/pull/13